### PR TITLE
Fix right toolbar margin causing page overflow

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -263,7 +263,11 @@ function updateToolbarHeight() {
                 const margin = Math.floor(
                     settings.topBottomMargin / window.visualViewport.scale
                 )
-                toolbarIframe.style.margin = `0 ${margin}px`
+                if (settings.defaultPosition === 'left') {
+                    toolbarIframe.style.margin = `0 ${margin}px 0 0`
+                } else {
+                    toolbarIframe.style.margin = `0 0 0 ${margin}px`
+                }
             }
         }
     }


### PR DESCRIPTION
  Summary

  • Fixes toolbar positioning bug where right-positioned toolbar with gap setting would extend beyond viewport
  • Prevents horizontal page overflow on responsive sites with precise viewport width constraints
  • Applies margin only to the appropriate side instead of both sides

  Bug reproduction

  Settings used:
  - Toolbar height: 36px
  - Toolbar width: 50%
  - Gap from edge: 0px
  - Toolbar position: Right

  Test page: https://www.xda-developers.com/why-i-replaced-wps-office-with-this-lightweight-alternative/
  (Bug more apparent on responsive sites with width=device-width viewport constraints)